### PR TITLE
Speed up ranking display by doing evil `ng-infinite-scroll` magic

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "jquery": "2.1.1",
     "lzma": "addaleax/LZMA-JS#development-all",
     "munkres-js": "^1.1.3",
-    "ng-infinite-scroll": "1.2.x",
+    "ng-infinite-scroll": "tradity/ngInfiniteScroll#debounced-scroll",
     "nsPopover": "nohros/nsPopover#622a133b344b",
     "open-sans-fontface": "~1.2.0",
     "zxcvbn": "^4.2.0"


### PR DESCRIPTION
Use a forked version of `ng-infinite-scroll` that breaks their tests
but doesn’t screw up the ranking display here.
